### PR TITLE
Add time_ms and some usage details to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,25 +47,25 @@ defmodule ImportantThing do
   alias Instrumental, as: I
 
   def compute_important_thing do
-    # tell Instrumental how long it takes to compute a
-    # value so we can know if our performance is changing
-    # over time.
-    I.time("ImportantThing.timing") do
-      value = compute_value
-      # tell Instrumental a value that was computed so we
-      # can track its change over time
-      I.gauge("ImportantThing.value", value)
-      value
-    end
+    # tell Instrumental how long it takes to run a
+    # computation so we can know if our performance
+    # is changing over time.
+    value = I.time("ImportantThing.timing", &ImportantThing.compute/0)
+    # tell Instrumental a value that was computed so we
+    # can track its change over time
+    I.gauge("ImportantThing.value", value)
+    value
   end
 
-  defp compute do
+  def compute do
     # tell Instrumental we computed a value so we can know
     # how often that is happening.
     I.increment("ImportantThing.computed")
-    do_some_hard_stuff_here
+
+    # do some hard stuff here
   end
 end
+
 ```
 
 * `alias` optional :smiley:

--- a/README.md
+++ b/README.md
@@ -67,9 +67,30 @@ defmodule ImportantThing do
 end
 
 ```
-
 * `alias` optional :smiley:
 
+
+### Functions
+
+```elixir
+# increments
+Instrumental.increment("metric.name");
+
+# gauges
+Instrumental.gauge("metric.name", 82.12);
+
+# notices
+Instrumental.notice("An event occurred");
+
+# timing a function (in seconds)
+Instrumental.time("metric.name", &Something.function/0);
+Instrumental.time("metric.name", fn -> Something.function(arg1) end)
+
+# timing a function (in milliseconds)
+Instrumental.time_ms("metric.name", &Something.function/0);
+Instrumental.time_ms("metric.name", fn -> Something.function(arg1) end)
+
+```
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,40 @@ config :instrumental,
 ### Options
 
   * token (required) - api key for authenticating with instrumental
-  * host (optional) - host of instrumental collector
-  * port (optional) - port of instrumental collector
+  * host (optional) - host of instrumental collector, *default: collector.instrumentalapp.com*
+  * port (optional) - port of instrumental collector, *default: 8000*
+
+
+## Usage
+
+```elixir
+defmodule ImportantThing do
+  alias Instrumental, as: I
+
+  def compute_important_thing do
+    # tell Instrumental how long it takes to compute a
+    # value so we can know if our performance is changing
+    # over time.
+    I.time("ImportantThing.timing") do
+      value = compute_value
+      # tell Instrumental a value that was computed so we
+      # can track its change over time
+      I.gauge("ImportantThing.value", value)
+      value
+    end
+  end
+
+  defp compute do
+    # tell Instrumental we computed a value so we can know
+    # how often that is happening.
+    I.increment("ImportantThing.computed")
+    do_some_hard_stuff_here
+  end
+end
+```
+
+* `alias` optional :smiley:
+
 
 ## Authors
 

--- a/lib/instrumental.ex
+++ b/lib/instrumental.ex
@@ -48,16 +48,20 @@ defmodule Instrumental do
   end
 
   def time(metric, multiplier \\ 1, timeout \\ :infinity, fun) when is_binary(metric) and is_function(fun) do
-    start  = Time.unix_monotonic
-    result = nil
-    try do
-      task     = Task.async fn -> fun.() end
-      result   = Task.await(task, timeout)
-    after
-      duration = Time.unix_monotonic - start
-      gauge(metric, (duration * multiplier), start)
-    end
+    start = :os.system_time(:milli_seconds)
+    result =
+      try do
+        task   = Task.async fn -> fun.() end
+        Task.await(task, timeout)
+      after
+        duration = (:os.system_time(:milli_seconds) - start) / 1000
+        gauge(metric, (duration * multiplier), start / 1000)
+      end
     result
+  end
+
+  def time_ms(metric, timeout \\ :infinity, fun) when is_binary(metric) and is_function(fun) do
+    time(metric, 1000, timeout, fun)
   end
 
   def version do

--- a/test/instrumental_test.exs
+++ b/test/instrumental_test.exs
@@ -1,3 +1,17 @@
 defmodule InstrumentalTest do
-  use ExUnit.Case
+  use ExUnit.Case#, async: true
+
+  test "time/4 returns the value of the passed function" do
+    metric   = "test.metric"
+    expected = 42
+
+    assert expected == Instrumental.time(metric, fn -> 42 end)
+  end
+
+  test "time_ms/3 returns the value of the passed function" do
+    metric   = "test.metric"
+    expected = 42
+
+    assert expected == Instrumental.time_ms(metric, fn -> 42 end)
+  end
 end


### PR DESCRIPTION
## What / Why

Add a millisecond timer to the time command for accuracy and  way to record the value in ms.

Update the README to have an annotated set of example code that is excecutable.
## Caveats

I think it is written correctly, but I would like to support passing in a pre-computed time in addition to the function form.
