### PR TITLE
Remove gauge_absolute

### DIFF
--- a/lib/instrumental/protocol.ex
+++ b/lib/instrumental/protocol.ex
@@ -11,10 +11,9 @@ defmodule Instrumental.Protocol do
   @metric_match Regex.compile!("\s")
   @increment "increment"
   @gauge "gauge"
-  @gauge_absolute "gauge_absolute"
   @notice "notice"
 
-  @type metric_type :: :increment | :gauge | :gauge_absolute | :notice
+  @type metric_type :: :increment | :gauge | :notice
 
   @doc """
   String to be sent to instrumental connection to perform authentication.
@@ -37,12 +36,6 @@ defmodule Instrumental.Protocol do
   def format(:gauge, metric, value, time) do
     case metric_valid?(metric) do
       true  -> {:ok, build_command([@gauge, metric, value, time])}
-      false -> {:error, :invalid_metric}
-    end
-  end
-  def format(:gauge_absolute, metric, value, time) do
-    case metric_valid?(metric) do
-      true  -> {:ok, build_command([@gauge_absolute, metric, value, time])}
       false -> {:error, :invalid_metric}
     end
   end


### PR DESCRIPTION
The gauge_absolute command is long since deprecated and removed.
